### PR TITLE
Avoid segment fault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.0)
 
+# CMAKE_BUILD_TYPE
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+            "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel"
+            FORCE)
+endif()
+
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG")
+
 include_directories(${CMAKE_SOURCE_DIR})
 add_subdirectory(paddle)
 add_subdirectory(src)


### PR DESCRIPTION
fix #59  segment fault
fix #60  make tape compiled with the same optimization flag `-O3` in default `releasewithdebuginfo` build mode.